### PR TITLE
Fix: Postcard use static images

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -17,7 +17,10 @@ export default function PostCard({ post, showTag = false }: PostCardProps) {
     : '--';
 
   // 從 Notion 頁面獲取封面圖片
-  const coverImage = (post.cover?.external?.url || post.cover?.file?.url) ? `/images/${post.properties?.Slug.rich_text[0]?.plain_text}.webp` : '/images/logo.jpg';
+  const coverImage =
+    post.cover?.external?.url || post.cover?.file?.url
+      ? `/images/${post.properties?.Slug.rich_text[0]?.plain_text}.webp`
+      : '/images/logo.jpg';
 
   const author = post.properties.Author?.rich_text[0]?.plain_text || '不具名';
 


### PR DESCRIPTION
首頁卡片換成靜態圖片，避免 seo 爬蟲拿到過期的圖